### PR TITLE
Exercise Panel Bug Fix

### DIFF
--- a/fytProject/components/ExercisePanel.js
+++ b/fytProject/components/ExercisePanel.js
@@ -92,6 +92,7 @@ class ExercisePanel extends React.Component {
       this.props.selectedWorkout
     );
     this.setState({
+      expand: true,
       leftActionActivated: false
     });
   }


### PR DESCRIPTION
---
name: Exercise Panel Bug Fix
about: Fixed Exercise Panel Bug

---
## Pull Request

**Related Issue**
https://github.com/astewartgit/Fyt/issues/4

**Describe the solution you implemented**
Now after deleting an Exercise Panel, the panel that replaces it is always expanded, rather than changing to match the state of the deleted panel.

**Describe alternatives you've considered**
 If the desired functionality is to leave this panel unchanged, set expand to the state of that panel before the previous panel was deleted, rather than true in line 95 of ExcersizePanel.js

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
